### PR TITLE
Add MongoDB Authentication to our Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ And, that:
 ```
 is one of the key-value pairs in of `ITEM_PIPELINES` in `/web_scraping/scrapy/schools/schools/settings.py` by uncommenting the line. If you don't want to use the pipeline, remove the element.
 
+You will also need to set the "MONGO\_USERNAME" and "MONGO\_PASSWORD" properties in order to connect to MongoDB. 
+
 Finally, inside `/web_scraping`, run:
 ```bash
 # build the containers and run in the background

--- a/scrapy/schools/schools/pipelines.py
+++ b/scrapy/schools/schools/pipelines.py
@@ -98,23 +98,27 @@ class MongoDBPipeline(object):
 
     collection_name = 'outputItems'
 
-    def __init__(self, mongo_uri, mongo_db):
+    def __init__(self, mongo_uri, mongo_db, mongo_user='admin', mongo_pwd):
         self.mongo_uri = mongo_uri
         self.mongo_db = mongo_db
+        self.mongo_user = mongo_user
+        self.mongo_password = mongo_pwd
 
     @classmethod
     def from_crawler(cls, crawler):
         # pull in information from settings.py
         return cls(
             mongo_uri=crawler.settings.get('MONGO_URI'),
-            mongo_db=crawler.settings.get('MONGO_DATABASE', 'items')
+            mongo_db=crawler.settings.get('MONGO_DATABASE', 'items'),
+            mongo_user=crawler.settings.get('MONGO_USERNAME'),
+            mongo_pwd=crawler.settings.get('MONGO_PASSWORD')
         )
 
     def open_spider(self, spider):
         # initializing spider
         # opening db connection
         print("MONGO URI: " + str(self.mongo_uri))
-        self.client = pymongo.MongoClient(self.mongo_uri)
+        self.client = pymongo.MongoClient(self.mongo_uri, username=self.mongo_user, password=self.mongo_password)
         print("MONGO CLIENT SET UP SUCCESSFULLY")
         print("Self MONGO DB: " + str(self.mongo_db))
         self.db = self.client[self.mongo_db]

--- a/scrapy/schools/schools/pipelines.py
+++ b/scrapy/schools/schools/pipelines.py
@@ -98,11 +98,13 @@ class MongoDBPipeline(object):
 
     collection_name = 'outputItems'
 
-    def __init__(self, mongo_uri, mongo_db, mongo_user='admin', mongo_pwd):
+    def __init__(self, mongo_uri, mongo_db, mongo_user='admin', mongo_pwd='', mongo_repl = False, mongo_repl_name=''):
         self.mongo_uri = mongo_uri
         self.mongo_db = mongo_db
         self.mongo_user = mongo_user
         self.mongo_password = mongo_pwd
+        self.mongo_replication = mongo_repl
+        self.mongo_replica_set_name=mongo_repl_name
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -111,14 +113,19 @@ class MongoDBPipeline(object):
             mongo_uri=crawler.settings.get('MONGO_URI'),
             mongo_db=crawler.settings.get('MONGO_DATABASE', 'items'),
             mongo_user=crawler.settings.get('MONGO_USERNAME'),
-            mongo_pwd=crawler.settings.get('MONGO_PASSWORD')
+            mongo_pwd=crawler.settings.get('MONGO_PASSWORD'),
+            mongo_repl=crawler.settings.get('MONGO_REPLICATION'),
+            mongo_repl_name=crawler.settings.get('MONGO_REPLICA_SET')
         )
 
     def open_spider(self, spider):
         # initializing spider
         # opening db connection
         print("MONGO URI: " + str(self.mongo_uri))
-        self.client = pymongo.MongoClient(self.mongo_uri, username=self.mongo_user, password=self.mongo_password)
+        if self.mongo_replication:
+            self.client = pymongo.MongoClient(self.mongo_uri, replicaSet = self.mongo_replica_set_name, username = self.mongo_user, password = self.mongo_password)
+        else:
+            self.client = pymongo.MongoClient(self.mongo_uri, username=self.mongo_user, password=self.mongo_password)
         print("MONGO CLIENT SET UP SUCCESSFULLY")
         print("Self MONGO DB: " + str(self.mongo_db))
         self.db = self.client[self.mongo_db]

--- a/scrapy/schools/schools/settings.py
+++ b/scrapy/schools/schools/settings.py
@@ -114,6 +114,9 @@ MONGO_URI = 'mongodb://localhost:27017'
 
 MONGO_DATABASE = 'schoolSpider' # database (not collection) name
 
+MONGO_USERNAME = 'admin' # could probably make a "schoolCrawler" user to use here instead
+
+MONGO_PASSWORD = 'someSecretPasswordThatWeWillNotForget' # Replace with actual password
 
 IMAGES_STORE = 'images'
 FILES_STORE = 'files'

--- a/scrapy/schools/schools/settings.py
+++ b/scrapy/schools/schools/settings.py
@@ -108,15 +108,20 @@ ITEM_PIPELINES = {
 }
 # running locally without containers
 MONGO_URI = 'mongodb://localhost:27017' 
+#MONGO_URI = '10.0.2.4'
 # connect to MongoDB which is running in mongodb_container.
 #MONGO_URI = 'mongodb://mongodb_container:27017'
 #MONGO_URI = 'someBadURI'
+
+MONGO_REPLICATION = False
+
+MONGO_REPLICA_SET = 'mongoCluster' # replica set name if used
 
 MONGO_DATABASE = 'schoolSpider' # database (not collection) name
 
 MONGO_USERNAME = 'admin' # could probably make a "schoolCrawler" user to use here instead
 
-MONGO_PASSWORD = 'someSecretPasswordThatWeWillNotForget' # Replace with actual password
+MONGO_PASSWORD = 'mdipass' # Replace with actual password
 
 IMAGES_STORE = 'images'
 FILES_STORE = 'files'


### PR DESCRIPTION
The purpose of this branch is to add settings in our pymongo.MongoClient that allow us to connect to a Mongo Database that is password-protected. I have also included the option to connect to a replicated Mongo cluster, if we decide that's a direction we want to take (for data availability and protection).

To test:
1. Stop whatever Mongo you have running
2. Start a new Mongo instance via Docker (or Linux commands, whichever you prefer): docker run -p 27017:27017 --name mongodb -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=somePassword
3. In settings.py, configure the Mongo Username and Password properties to match what you set up. Also confirm that the "replica set" property is set to "False"
4. Run your crawler with your favorite test url list! For example (python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt && scrapy crawl schoolspider -a school_list=./schools/spiders/test_urls.tsv)
5. After it finishes or you get bored and stop it, confirm in your MongoDB that data was written: docker exec -it mongodb bash, then mongo -u admin -p yourPasswordAgain, then show dbs (note that windows users need to add "winpty" before the first command)
6. You can also repeat this test with mismatched passwords to see that it's not writing to Mongo if you have the wrong auth information!

Report any bugs or issues that you encounter!