### PR TITLE
Resolve Hanging Issue. ACTION REQUIRED

### DIFF
--- a/scrapy/schools/schools/spiders/scrapy_vanilla.py
+++ b/scrapy/schools/schools/spiders/scrapy_vanilla.py
@@ -295,14 +295,31 @@ class CharterSchoolSpider(CrawlSpider):
         """
         file_urls = []
         selector = 'a[href$=".pdf"]::attr(href), a[href$=".doc"]::attr(href), a[href$=".docx"]::attr(href)'
-        try:
+        if 'text/html' in str(response.headers['Content-Type']):
             extracted_links = response.css(selector).extract()
-        except NotSupported:
+            print("Reading response HTML")
+        else:
             extracted_links = []
-            if 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' in str(response.headers['Content-Type']) or 'application/pdf' in str(response.headers['Content-Type']):
-                extracted_links.append(response.url)
+            if 'application/pdf' in str(response.headers['Content-Type']):
+                if response.url.endswith('/'):
+                    file_url = response.url[:-1] + '.pdf'
+                else:
+                    file_url = response.url + '.pdf'
+                extracted_links.append(file_url)
+            elif 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' in str(response.headers['Content-Type']):
+                if response.url.endswith('/'):
+                    file_url = response.url[:-1] + '.docx'
+                else:
+                    file_url = response.url + '.docx'
+                extracted_links.append(file_url)
+            elif 'application/msword' in str(response.headers['Content-Type']):
+                if response.url.endswith('/'):
+                    file_url = response.url[:-1] + '.doc'
+                else:
+                    file_url = response.url + '.doc'
+                extracted_links.append(file_url)
 #            print("Cannot extract file. Domain is: " + str(domain))
-#            print("Content-Type Header: " + str(response.headers['Content-Type']))
+        print("Content-Type Header: " + str(response.headers['Content-Type']))
 #            print("\n\n\n\nHeaders: " + str(response.headers.keys()) + "\n\n\n\n")
         print("PDF FOUND", extracted_links)
         

--- a/scrapy/schools/schools/spiders/test_urls.tsv
+++ b/scrapy/schools/schools/spiders/test_urls.tsv
@@ -1,5 +1,2 @@
 NCESSCH	URL_2019
-3.70014E+11	http://www.charlottesecondary.org/
-3.70014E+11	http://www.kippcharlotte.org/
-3.70014E+11	http://www.socratesacademy.us/
 3.70014E+11	https://www.achievementfirst.org/

--- a/scrapy/schools/schools/spiders/test_urls.tsv
+++ b/scrapy/schools/schools/spiders/test_urls.tsv
@@ -2,3 +2,4 @@ NCESSCH	URL_2019
 3.70014E+11	http://www.charlottesecondary.org/
 3.70014E+11	http://www.kippcharlotte.org/
 3.70014E+11	http://www.socratesacademy.us/
+3.70014E+11	https://www.achievementfirst.org/


### PR DESCRIPTION
The purpose of this branch is to try to slap another band-aid on the hanging issue that we have run into with some URLs. I noticed over the weekend that a particular PDF document scraped from the achievementfirst website did not belong. It was linked to a "spectrum.com" url, and the document's url itself appeared to be dead, redirecting the user to the spectrum homepage (url for reference: https://www.spectrum.com/content/dam/spectrum/residential/en/pdfs/spectrum-internet-assist/Nov2019_SIA_Eligibility_Form_FINAL_REV.pdf ). The fact that it did this likely caused at least one of the hanging issues via the "requests" library in Python (see below; I had originally thought this to be a Textract issue). 

To resolve this, I added some basic logic to test if a file's url is within the same domain as the base url. This logic is a simple partial string comparison. ACTION REQUIRED: To my understanding, there are some urls that use things like "sites.google.com/someschool", which will get missed by the extremely simple string comparison logic that I have implemented here; if anyone has guidance regarding urls like this, I would love to work with you to create more effective comparison logic. ACTION REQUIRED: Along the same line, this basic logic will skip over too many documents -- if a document is stored external to the domain (for example an S3 bucket), it will be missed, or if a document comes from another domain (like a regional or district-level document), it will be missed, etc. The logic implemented needs refinement, although so far it is working to scrape data in this more limited way. We can discuss in a meeting or in the comments below.

There also appears to be a known issue with the "urllib3" library, which seems to not play nice all the time when processes are multithreaded (as Scrapy is): https://stackoverflow.com/questions/24628866/why-does-my-program-hang-after-urllib3-logs-starting-new-https-connection -- the "requests" library, which we make use of, uses the urllib3 library. If the hanging issue persists, we may want to try re-implementing our use of the requests library to directly use the urllib3 library in order to manage connection pools ourselves. 

To test this:
1. Start your local MongoDB: docker pull mongo && docker run -p 27017:27017 --name mongodb -d mongo (or just docker start mongodb if you already have a container locally)
2. Ensure you're configured to connect to MongoDB (see the README)
3. Navigate to the "scrapy/schools" directory
4. Start your virtual env: python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
5. Run the scraper with only the AchievementFirst domain -- use the test_urls.tsv file as your "school_list" input: scrapy crawl schoolspider -a school_list=./schools/spiders/test_urls.tsv
6. Confirm that it (eventually) completes the crawl! It should pick up a lot of different documents too...
7. Optional: Run with the full school list. As of writing this, I am running a crawl with the first 500 urls from the charter school list, and it's taking a while, but not hanging